### PR TITLE
Allow project to be used with Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "rashid2538/php-htmldiff",
+    "type": "library",
+    "description": "A library for comparing two HTML files/snippets and highlighting the differences using simple HTML.",
+    "keywords": [
+        "diff",
+        "html"
+    ],
+    "homepage": "https://github.com/rashid2538/php-htmldiff",
+    "license": "",
+    "authors": [
+        {
+            "name": "Rashid Mohamad",
+            "email": "rashid2538@gmail.com",
+            "homepage": "http://www.dexteratlab.com/",
+            "role": "Developer"
+        },
+        {
+            "name": "Michael Robinson",
+            "email": "mike@pagesofinterest.net",
+            "homepage": "http://pagesofinterest.net/",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/rashid2538/php-htmldiff/issues"
+    },
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "files": [
+            "HtmlDiff.php"
+        ]
+    }
+}


### PR DESCRIPTION
> Composer is a tool for dependency management in PHP. It allows you to declare the dependent libraries your project needs and it will install them in your project for you.

I've added the `composer.json` file to this project to allow it to be used with [Composer](http://getcomposer.org/doc/00-intro.md). The [Composer documentation](http://getcomposer.org/doc/04-schema.md#authors) describes this file.
