### PR TITLE
fix for unicode words

### DIFF
--- a/HtmlDiff.php
+++ b/HtmlDiff.php
@@ -66,7 +66,7 @@
 							$current_word = $character;
 							$mode = 'whitespace';
 						} else {
-							if( ctype_alnum( $character ) ) {
+							if( ctype_alnum( $character ) && ( strlen($current_word) == 0 || ctype_alnum( $current_word ) ) ) {
 								$current_word .= $character;
 							} else {
 								$words[] = $current_word;


### PR DESCRIPTION
html1: `测试A`
html2: `测试B`
result: `测<del>试A</del><ins>试B</ins>`

Neither 试A nor 试B is a word. So alphanumeric character should not be appended to the unicode string. The result should be: 

`测试<del>A</del><ins>B</ins>`
